### PR TITLE
Fix links to timeanddate.com to have the right time

### DIFF
--- a/_content/talks/ai.md
+++ b/_content/talks/ai.md
@@ -3,7 +3,6 @@ layout: talk
 title: "Built-in AI APIs for the Web"
 authors: "Thomas Steiner"
 date: "2025-06-02T17:30:00"
-dateiso: "2025-06-02T17:30:00"
 imgsrc: "/img/talks/thomas.jpeg"
 imgalt: "Thomas Steiner"
 ---

--- a/_content/talks/assistive.md
+++ b/_content/talks/assistive.md
@@ -3,7 +3,6 @@ layout: talk
 title: "Automating Assistive Tech with Standards"
 authors: "Mike Pennisi & Chris Cuellar"
 date: "2025-06-02T17:00:00"
-dateiso: "2025-06-02T17:00:00"
 imgsrc: "/img/talks/bocoup.png"
 imgalt: "Bocoup logo"
 ---

--- a/_content/talks/jsr.md
+++ b/_content/talks/jsr.md
@@ -3,7 +3,6 @@ layout: talk
 title: "JSR: under the hood & native support in the ecosystem"
 authors: "Leo Kettmeir"
 date: "2025-06-02T12:00:00"
-dateiso: "2025-06-02T12:00:00"
 imgsrc: "/img/talks/leo.jpg"
 imgalt: "Leo Kettmeir"
 ---

--- a/_content/talks/nodejs.md
+++ b/_content/talks/nodejs.md
@@ -3,7 +3,6 @@ layout: talk
 title: "Bridging CommonJS and ESM in Node.js"
 authors: "Joyee Cheung"
 date: "2025-06-02T12:30:00"
-dateiso: "2025-06-02T12:30:00"
 imgsrc: "/img/talks/joyee.jpeg"
 imgalt: "Joyee Cheung"
 ---

--- a/_content/talks/porffor.md
+++ b/_content/talks/porffor.md
@@ -3,7 +3,6 @@ layout: talk
 title: "Compiling JavaScript ahead-of-time"
 authors: "Oliver Medhurst"
 date: "2025-06-02T10:30:00"
-dateiso: "2025-06-02T10:30:00"
 imgsrc: "/img/talks/oliver.jpeg"
 imgalt: "Oliver Medhurst"
 ---

--- a/_content/talks/temporal.md
+++ b/_content/talks/temporal.md
@@ -3,7 +3,6 @@ layout: talk
 title: "Cross-Engine Contributions at Scale: How newcomers accelerated Temporal and Upsert in SpiderMonkey, V8, and Boa"
 authors: "Jonas Haukenes, Mikhail Barash & Shane Carr"
 date: "2025-06-02T13:00:00"
-dateiso: "2025-06-02T13:00:00"
 ---
 
 Join us for a story through our journey implementing TC39 proposals in SpiderMonkey, V8, and Boa.

--- a/_content/talks/web-components.md
+++ b/_content/talks/web-components.md
@@ -3,7 +3,6 @@ layout: talk
 title: "Versioned Web Components"
 authors: "Christian Ulbrich"
 date: "2025-06-02T15:30:00"
-dateiso: "2025-06-02T15:30:00"
 ---
 
 While Web Components are far from new, they are seeing more and more adaption for a multitude of use cases, both as containers for micro-frontends as well as a way of building framework agnostic UI libraries. One of the biggest challenges is, that there is no way of overriding existing web components, or more precisely custom elements can only be defined once for a certain tag name. While there is a proposal for alleviating this, called scoped custom element registries, it never came really to fruition and has several problems.

--- a/_content/talks/wintertc.md
+++ b/_content/talks/wintertc.md
@@ -3,7 +3,6 @@ layout: talk
 title: "WinterTC: a standard for server-side runtimes"
 authors: "Andreu Botella & Luca Casonato"
 date: "2025-06-02T11:00:00"
-dateiso: "2025-06-02T11:00:00"
 imgsrc: "/img/talks/andreu.jpg"
 imgalt: "Andreu Botella"
 imgsrc2: "/img/talks/luca.jpg"

--- a/_content/talks/wpe-android.md
+++ b/_content/talks/wpe-android.md
@@ -3,7 +3,6 @@ layout: talk
 title: "Jumping Over the Garden Wall - WPE WebKit on Android"
 authors: "Adrián Pérez de Castro"
 date: "2025-06-02T16:00:00"
-dateiso: "2025-06-02T16:00:00"
 imgsrc: "/img/talks/adrian.jpg"
 imgalt: "Adrián Pérez de Castro"
 ---

--- a/index.md
+++ b/index.md
@@ -83,7 +83,7 @@ layout: default
 
 #### by {{ talk.data.authors }}
 
-##### Date: [{{ talk.data.date | date: "%Y/%m/%d - %H:%M CEST (UTC+2)" }}](https://www.timeanddate.com/worldclock/fixedtime.html?iso={{ talk.data.dateiso }})
+##### Date: [{{ talk.data.date | date: "%Y/%m/%d - %H:%M CEST (UTC+2)" }}](https://www.timeanddate.com/worldclock/fixedtime.html?iso={{ talk.data.date }}&p1=681)
 
 {% if talk.data.video %}
 


### PR DESCRIPTION
In the details of the talks for 2025, the links to timeanddate.com link to the time of the talk as if it were in UTC, rather than CEST, leading to the wrong computed time in some timezone.

This happens because talks have `date` and `dateiso` fields, where the former is in CEST and the latter is supposed to be in UTC, but for 2025 both are set to the CEST value. Rather than setting the right `dateiso` value, this PR instead removes that field, and updates the timeanddate.com link so the time is interpreted as being in the timezone for A Coruña, rather than in UTC.
